### PR TITLE
Foreslår endring fra en klasse NewsletterBase til et interface INewsletterBase

### DIFF
--- a/src/Newsletter/EPiCode.Newsletter.csproj
+++ b/src/Newsletter/EPiCode.Newsletter.csproj
@@ -65,7 +65,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\</OutputPath>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <BaseAddress>285212672</BaseAddress>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>

--- a/src/Newsletter/EPiCode.Newsletter.csproj
+++ b/src/Newsletter/EPiCode.Newsletter.csproj
@@ -41,7 +41,7 @@
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\</OutputPath>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <BaseAddress>285212672</BaseAddress>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
@@ -670,16 +670,5 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <Target Name="CreateAddOnPackage">
-    <Exec Command="..\.nuget\nuget pack EPiCode.Newsletter.csproj -OutputDirectory $(OutputPath)" />
-  </Target>
-  <Target Name="AfterBuild" DependsOnTargets="CreateAddOnPackage">
-  </Target>
-  <Import Project="..\.nuget\nuget.targets" />
-  <Target Name="AfterBuild" DependsOnTargets="CreateAddOnPackage">
-  </Target>
-  <Target Name="CreateAddOnPackage">
-    <Exec Command="..\.nuget\nuget pack EPiCode.Newsletter.nuspec -OutputDirectory $(OutputPath)" />
   </Target>
 </Project>

--- a/src/Newsletter/EPiCode.Newsletter.nuspec
+++ b/src/Newsletter/EPiCode.Newsletter.nuspec
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>EPiCode.Newsletter</id>
+        <id>Regjeringen.Newsletter</id>
         <version>$version$</version>
         <authors>The EPiCode Community</authors>
         <owners>BV Network AS</owners>
         <projectUrl>https://github.com/BVNetwork/Newsletter</projectUrl>
         <iconUrl>http://www.coderesort.com/favicon.ico</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Create a new newsletter page, send it to your recipients as an email. Easy to use and quick to integrate.</description>
+        <description>Forked from EpiCode.Newsletter. Create a new newsletter page, send it to your recipients as an email. Easy to use and quick to integrate.</description>
         <summary>Sends pages as newsletters through the EPiServer UI.</summary>
         <references>
             <reference file="BVNetwork.EPiSendMail.dll" />

--- a/src/Newsletter/EPiCode.Newsletter.nuspec
+++ b/src/Newsletter/EPiCode.Newsletter.nuspec
@@ -46,7 +46,7 @@
         <file src="..\InstallationResources\web.config.uninstall.xdt"
               target="content" />-->
         
-        <file src="bin\debug\BVNetwork.EPiSendMail.dll"
+        <file src="bin\BVNetwork.EPiSendMail.dll"
               target="lib\net45\BVNetwork.EPiSendMail.dll" />
         <file src="references\aspNetEmail.dll"
               target="lib\net45\aspNetEmail.dll" />

--- a/src/Newsletter/Initialization/InitializeNewsletterEvents.cs
+++ b/src/Newsletter/Initialization/InitializeNewsletterEvents.cs
@@ -41,7 +41,7 @@ namespace BVNetwork.EPiSendMail.Initialization
                 return;
             }
 
-            NewsletterBase correctBase = page as NewsletterBase;
+            INewsletterBase correctBase = page as INewsletterBase;
             if (correctBase != null)
             {
                 Job job = Job.LoadByPageId(page.PageLink.ID);
@@ -65,7 +65,7 @@ namespace BVNetwork.EPiSendMail.Initialization
                 return;
             }
 
-            NewsletterBase correctBase = page as NewsletterBase;
+            INewsletterBase correctBase = page as INewsletterBase;
             if (correctBase != null)
             {
                 Job job = Job.LoadByPageId(page.PageLink.ID);
@@ -85,7 +85,7 @@ namespace BVNetwork.EPiSendMail.Initialization
                 return;
             }
 
-            NewsletterBase correctBase = page as NewsletterBase;
+            INewsletterBase correctBase = page as INewsletterBase;
             if (correctBase != null)
             {
                 Job job = Job.LoadByPageId(page.PageLink.ID);

--- a/src/Newsletter/Library/NewsletterBase.cs
+++ b/src/Newsletter/Library/NewsletterBase.cs
@@ -1,26 +1,24 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Security.Cryptography;
 using BVNetwork.EPiSendMail.Contracts;
-using EPiServer.Core;
 using EPiServer.DataAbstraction;
 
 namespace BVNetwork.EPiSendMail
 {
-	public class NewsletterBase : PageData, IRegisterNewsletterDetailsView
+	public interface INewsletterBase : IRegisterNewsletterDetailsView
 	{
 
 		[Display(
 			GroupName = SystemTabNames.Content,
-            Name = "From Address",
-            Description = "The email address that will show as the from field in most email clients",
+			Name = "From Address",
+			Description = "The email address that will show as the from field in most email clients",
 			Order = 110)]
-		public virtual string MailSender { get; set; }
+		string MailSender { get; set; }
 
 		[Display(
 			GroupName = SystemTabNames.Content,
-            Name = "Email Subject",
-            Description = "The subject line of the email. If empty, the name of the page wil be used",
+			Name = "Email Subject",
+			Description = "The subject line of the email. If empty, the name of the page wil be used",
 			Order = 120)]
-		public virtual string MailSubject { get; set; }
+		string MailSubject { get; set; }
 	}
 }

--- a/src/Newsletter/UIExtensions/NewsLetterDetailsView.cs
+++ b/src/Newsletter/UIExtensions/NewsLetterDetailsView.cs
@@ -7,7 +7,7 @@ using EPiServer.Shell;
 namespace BVNetwork.EPiSendMail.UIExtensions
 {
     [ServiceConfiguration(typeof(EPiServer.Shell.ViewConfiguration))]
-    public class NewsLetterDetailsView : ViewConfiguration<NewsletterBase>
+    public class NewsLetterDetailsView : ViewConfiguration<INewsletterBase>
     {
         public NewsLetterDetailsView()
         {

--- a/src/Newsletter/UIExtensions/NewsletterDetailsViewUiDescriptor.cs
+++ b/src/Newsletter/UIExtensions/NewsletterDetailsViewUiDescriptor.cs
@@ -4,7 +4,7 @@ using EPiServer.Shell;
 namespace BVNetwork.EPiSendMail.UIExtensions
 {
     [UIDescriptorRegistration]
-    public class NewsletterDetailsViewUiDescriptor : UIDescriptor<NewsletterBase>
+    public class NewsletterDetailsViewUiDescriptor : UIDescriptor<INewsletterBase>
     {
 
     }


### PR DESCRIPTION
Hei karer.
Ikke aksepter dette pull requestet da jeg har gjort endel endringer i project og nuspec filene også ;)
Det er bare ment for å illustrere hvordan vi ønkser å unngå at det er en spesifikk baseklasse som ligger til grunn for Newsletter malen. Det hadde (for oss;) vært mye bedre om de 2 påkrevde egenskapene ble definert i ett interface, slik at vi kan la Newletter sidetypen i vårt prosjekt arve fra vår egen baseklasse. Vi kjører nå med denne interface varianten på Regjeringen.no prosjektet...