### PR TITLE
Adding a new interface "INewsletterBase"

### DIFF
--- a/src/Newsletter/EPiCode.Newsletter.csproj
+++ b/src/Newsletter/EPiCode.Newsletter.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Library\HtmlHelpers.cs" />
     <Compile Include="Library\IMailSenderVerification.cs" />
     <Compile Include="Contracts\IPopulateCustomProperties.cs" />
+    <Compile Include="Library\INewsletterBase.cs" />
     <Compile Include="Library\MailInformation.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Newsletter/Initialization/InitializeNewsletterEvents.cs
+++ b/src/Newsletter/Initialization/InitializeNewsletterEvents.cs
@@ -41,7 +41,7 @@ namespace BVNetwork.EPiSendMail.Initialization
                 return;
             }
 
-            NewsletterBase correctBase = page as NewsletterBase;
+            var correctBase = page as INewsletterBase;
             if (correctBase != null)
             {
                 Job job = Job.LoadByPageId(page.PageLink.ID);
@@ -65,7 +65,7 @@ namespace BVNetwork.EPiSendMail.Initialization
                 return;
             }
 
-            NewsletterBase correctBase = page as NewsletterBase;
+            var correctBase = page as INewsletterBase;
             if (correctBase != null)
             {
                 Job job = Job.LoadByPageId(page.PageLink.ID);
@@ -85,7 +85,7 @@ namespace BVNetwork.EPiSendMail.Initialization
                 return;
             }
 
-            NewsletterBase correctBase = page as NewsletterBase;
+            var correctBase = page as INewsletterBase;
             if (correctBase != null)
             {
                 Job job = Job.LoadByPageId(page.PageLink.ID);

--- a/src/Newsletter/Library/INewsletterBase.cs
+++ b/src/Newsletter/Library/INewsletterBase.cs
@@ -1,0 +1,8 @@
+﻿namespace BVNetwork.EPiSendMail
+{
+    public interface INewsletterBase
+    {
+        string MailSender { get; set; }
+        string MailSubject { get; set; }
+    }
+}

--- a/src/Newsletter/Library/NewsletterBase.cs
+++ b/src/Newsletter/Library/NewsletterBase.cs
@@ -1,25 +1,24 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Security.Cryptography;
 using BVNetwork.EPiSendMail.Contracts;
 using EPiServer.Core;
 using EPiServer.DataAbstraction;
 
 namespace BVNetwork.EPiSendMail
 {
-	public class NewsletterBase : PageData, IRegisterNewsletterDetailsView
+	public class NewsletterBase2 : PageData, INewsletterBase,IRegisterNewsletterDetailsView
 	{
 
 		[Display(
 			GroupName = SystemTabNames.Content,
-            Name = "From Address",
-            Description = "The email address that will show as the from field in most email clients",
+			Name = "From Address",
+			Description = "The email address that will show as the from field in most email clients",
 			Order = 110)]
 		public virtual string MailSender { get; set; }
 
 		[Display(
 			GroupName = SystemTabNames.Content,
-            Name = "Email Subject",
-            Description = "The subject line of the email. If empty, the name of the page wil be used",
+			Name = "Email Subject",
+			Description = "The subject line of the email. If empty, the name of the page wil be used",
 			Order = 120)]
 		public virtual string MailSubject { get; set; }
 	}

--- a/src/Newsletter/Library/NewsletterBase.cs
+++ b/src/Newsletter/Library/NewsletterBase.cs
@@ -5,7 +5,7 @@ using EPiServer.DataAbstraction;
 
 namespace BVNetwork.EPiSendMail
 {
-	public class NewsletterBase2 : PageData, INewsletterBase,IRegisterNewsletterDetailsView
+	public class NewsletterBase : PageData, INewsletterBase,IRegisterNewsletterDetailsView
 	{
 
 		[Display(

--- a/src/Newsletter/UIExtensions/NewsLetterDetailsView.cs
+++ b/src/Newsletter/UIExtensions/NewsLetterDetailsView.cs
@@ -7,7 +7,7 @@ using EPiServer.Shell;
 namespace BVNetwork.EPiSendMail.UIExtensions
 {
     [ServiceConfiguration(typeof(EPiServer.Shell.ViewConfiguration))]
-    public class NewsLetterDetailsView : ViewConfiguration<NewsletterBase>
+    public class NewsLetterDetailsView : ViewConfiguration<INewsletterBase>
     {
         public NewsLetterDetailsView()
         {

--- a/src/Newsletter/UIExtensions/NewsletterDetailsViewUiDescriptor.cs
+++ b/src/Newsletter/UIExtensions/NewsletterDetailsViewUiDescriptor.cs
@@ -4,7 +4,7 @@ using EPiServer.Shell;
 namespace BVNetwork.EPiSendMail.UIExtensions
 {
     [UIDescriptorRegistration]
-    public class NewsletterDetailsViewUiDescriptor : UIDescriptor<NewsletterBase>
+    public class NewsletterDetailsViewUiDescriptor : UIDescriptor<INewsletterBase>
     {
 
     }


### PR DESCRIPTION
We introduce an interface defining the required page properties and keep the NewsletterBase class. This will allow us to use another base class for our newsletter template, while the other solutions should work just fine :)